### PR TITLE
Fixa a barra azul de gerenciamento de oportunidades

### DIFF
--- a/assets-src/sass/theme-BaseV2.scss
+++ b/assets-src/sass/theme-BaseV2.scss
@@ -430,3 +430,9 @@ body.base-v2.controller-registration.action-evaluation {
 small.contchar {
     float: right;
 }
+
+
+//Trava a barra de Gerenciar Oportunidade
+.layout-entity {
+  overflow: visible !important;
+}


### PR DESCRIPTION
Aplica overflow: visible no elemento pai para funcionar o efeito stick e fixar a barra azul de gerenciamento de oportunidade. Na tela de oportunidade e na telas de configurações da oportunidade.

<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/705056b3-bfdc-41c6-a4d1-324475154e99" />
<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/ddcc6b83-1cf6-4c20-bccf-18e5649c6035" />
<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/214283c0-8ca9-4ed9-8916-bea79f5c4c8d" />
<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/3a453852-3d09-4349-aabb-feeee56188f8" />
